### PR TITLE
Add pyparsing and fix keyserver

### DIFF
--- a/Dockerfile.bootstrap
+++ b/Dockerfile.bootstrap
@@ -1,5 +1,5 @@
 FROM debian:stretch
-RUN apt update
+RUN apt update && apt -y upgrade
 RUN apt install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \
@@ -14,6 +14,7 @@ RUN apt install -y --no-install-recommends \
     python3-empy \
     python3-pkg-resources \
     python3-setuptools \
+    python3-pyparsing \
     qemu-user-static \
     software-properties-common
 ENV RASPBERRYPI_CROSS_COMPILE_TOOLCHAIN_PATH /usr/bin

--- a/ros2_dependencies.bash
+++ b/ros2_dependencies.bash
@@ -7,7 +7,7 @@ apt update
 apt -y --no-install-recommends install dirmngr
 
 echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" | tee /etc/apt/sources.list.d/ros-latest.list
-apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+apt-key adv --keyserver pgp.mit.edu --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 
 apt update
 apt -y install git wget


### PR DESCRIPTION
Add pyparsing to the crosscompiler, otherwise ament doesn't even run. Keyserver changed because the old one fails quite often, this was a recommended replacement.